### PR TITLE
💄Make “Statistiques” title align with the other pages titles

### DIFF
--- a/src/app/modules/statistics/components/statistics/statistics.component.html
+++ b/src/app/modules/statistics/components/statistics/statistics.component.html
@@ -1,4 +1,4 @@
-<h1 class="mt-4">{{ I18ns.statistics.title }}</h1>
+<h1>{{ I18ns.statistics.title }}</h1>
 <p class="mb-4 alto-grey fs-6b">{{ I18ns.statistics.subtitle }}</p>
 <!-- <alto-tabs
   class="mb-4 d-block fw-bold"


### PR DESCRIPTION
Ticket Notion ~> https://www.notion.so/usealto/LEAD-STATS-Statistiques-title-is-not-aligned-with-the-other-pages-titles-c301c8712b52485d8aa66cbd90ddff78?pvs=4

Before ~>
<img width="1141" alt="Capture d’écran 2023-07-10 à 14 48 51" src="https://github.com/usealto/assessment-front/assets/65304634/d639adf2-7e51-4076-9053-aa65a3f9bae8">

After ~>
<img width="1141" alt="Capture d’écran 2023-07-10 à 14 47 52" src="https://github.com/usealto/assessment-front/assets/65304634/8c5b9ebd-b3d2-4549-bc9f-d0b45617b7a9">

Y'avait trop d'espace entre le haut de la page et le titre "Statistiques" avant. 