### PR TITLE
reload users when editing a user

### DIFF
--- a/src/app/modules/lead-team/components/user-edit-form/user-edit-form.component.ts
+++ b/src/app/modules/lead-team/components/user-edit-form/user-edit-form.component.ts
@@ -91,6 +91,7 @@ export class UserEditFormComponent implements OnInit {
         .pipe(
           tap((user) => {
             this.editedUser.emit(user);
+            this.userService.resetUsers();
             this.activeOffcanvas.close();
           }),
         )

--- a/src/app/modules/profile/services/users-rest.service.ts
+++ b/src/app/modules/profile/services/users-rest.service.ts
@@ -34,6 +34,10 @@ export class UsersRestService {
     }
   }
 
+  resetUsers() {
+    this.userStore.users.value = [];
+  }
+
   getUsersFiltered(req: GetUsersRequestParams): Observable<UserDtoApi[]> {
     return this.userApi.getUsers({ ...req }).pipe(map((r) => r.data ?? []));
   }


### PR DESCRIPTION
https://www.notion.so/usealto/lead-team-User-tab-does-not-reload-when-editing-a-user-b058b49326d045848cda99f5b3559149?pvs=4