### PR TITLE
🐛 Refresh tags and questions caches based on some events

### DIFF
--- a/src/app/modules/programs/components/programs/programs.component.ts
+++ b/src/app/modules/programs/components/programs/programs.component.ts
@@ -116,6 +116,8 @@ export class ProgramsComponent implements OnInit {
         tap(() => {
           modalRef.close();
           this.getQuestions();
+          this.tagRestService.resetTags();
+          this.getTags();
         }),
         untilDestroyed(this),
       )
@@ -140,6 +142,7 @@ export class ProgramsComponent implements OnInit {
           modalRef.close();
           this.tagRestService.resetTags();
           this.getTags();
+          this.getQuestions();
         }),
         untilDestroyed(this),
       )
@@ -152,7 +155,15 @@ export class ProgramsComponent implements OnInit {
       panelClass: 'overflow-auto',
     });
     canvasRef.componentInstance.question = question;
-    canvasRef.componentInstance.createdQuestion.pipe(tap(() => this.getQuestions())).subscribe();
+    canvasRef.componentInstance.createdQuestion
+      .pipe(
+        tap(() => {
+          this.getQuestions();
+          this.tagRestService.resetTags();
+          this.getTags();
+        }),
+      )
+      .subscribe();
   }
 
   openSubmittedQuestionForm(question?: QuestionSubmittedDtoApi) {


### PR DESCRIPTION
Cette PR fais les traitements suivant : 
- Suppression question => Reload Tags pour refresh la colonne "questionsCount"
- Create/Update question => Possibilité d'assignation ou de suppression de tags à cette question => Reload Tags aussi
- Suppression Tag => Reload Questions pour mettre à jour la colonne "tags associés à cette question"

Notion Tickets ~>
https://www.notion.so/usealto/LEAD-Programs-When-deleting-a-tags-tags-does-not-reload-on-questions-0aa3d6e5b83d4df685ec57602fbdd548?pvs=4
https://www.notion.so/usealto/LEAD-Programs-Refresh-Question-Count-on-tags-when-creating-deleting-questions-79ac777a34a047fbae06b8beefff0155?pvs=4