### PR TITLE
💄 Increase the size of drop-down menu frames

### DIFF
--- a/src/app/modules/shared/components/period-filter/period-filter.component.stories.ts
+++ b/src/app/modules/shared/components/period-filter/period-filter.component.stories.ts
@@ -1,10 +1,11 @@
-import { type Meta, type StoryObj } from '@storybook/angular';
+import { componentWrapperDecorator, type Meta, type StoryObj } from '@storybook/angular';
 import { PeriodFilterComponent } from './period-filter.component';
 
 const meta: Meta<PeriodFilterComponent> = {
   title: 'Shared/PeriodFilter',
   component: PeriodFilterComponent,
   tags: ['autodocs'],
+  decorators: [componentWrapperDecorator((story) => `<div style="height: 12rem">${story}</div>`)],
   render: (args: PeriodFilterComponent) => ({
     props: {
       ...args,

--- a/src/app/modules/shared/components/progression-filter/progression-filter.component.stories.ts
+++ b/src/app/modules/shared/components/progression-filter/progression-filter.component.stories.ts
@@ -1,10 +1,11 @@
-import { type Meta, type StoryObj } from '@storybook/angular';
+import { componentWrapperDecorator, type Meta, type StoryObj } from '@storybook/angular';
 import { ProgressionFilterComponent } from './progression-filter.component';
 
 const meta: Meta<ProgressionFilterComponent> = {
   title: 'Shared/ProgressionFilter',
   component: ProgressionFilterComponent,
   tags: ['autodocs'],
+  decorators: [componentWrapperDecorator((story) => `<div style="height: 26rem">${story}</div>`)],
   render: (args: ProgressionFilterComponent) => ({
     props: {
       ...args,

--- a/src/app/modules/shared/components/score-filter/score-filter.component.stories.ts
+++ b/src/app/modules/shared/components/score-filter/score-filter.component.stories.ts
@@ -1,10 +1,11 @@
-import { type Meta, type StoryObj } from '@storybook/angular';
+import { componentWrapperDecorator, type Meta, type StoryObj } from '@storybook/angular';
 import { ScoreFilterComponent } from './score-filter.component';
 
 const meta: Meta<ScoreFilterComponent> = {
   title: 'Shared/ScoreFilter',
   component: ScoreFilterComponent,
   tags: ['autodocs'],
+  decorators: [componentWrapperDecorator((story) => `<div style="height: 26rem">${story}</div>`)],
   render: (args: ScoreFilterComponent) => ({
     props: {
       ...args,


### PR DESCRIPTION
This PR corrects the size of the frames surrounding the drop-down menus (PeriodFilter, ScoreFilter, ProgressionFilter) on storybook.

Tickets notion :
- https://www.notion.so/usealto/Enlarge-ProgressionFilter-dial-daf2d8b91dd347ffb04581b4ca372159?pvs=4
- https://www.notion.so/usealto/Enlarge-ScoreFilter-dial-37e3e2c50cf54def8c6fade61d25c075?pvs=4

Exemple of modification : 
Before ~>
<img width="1025" alt="Capture d’écran 2023-09-04 à 18 37 48" src="https://github.com/usealto/assessment-front/assets/65304634/5378ffc7-fcbf-426b-8fc5-dd3506de49a3">

After ~> 
<img width="1024" alt="Capture d’écran 2023-09-04 à 18 36 47" src="https://github.com/usealto/assessment-front/assets/65304634/6150c575-edc8-4658-9dd4-0a8b9e02dd34">
