### PR TITLE
🔨 Change chart labels to French

### DIFF
--- a/src/app/modules/statistics/services/statistics.service.ts
+++ b/src/app/modules/statistics/services/statistics.service.ts
@@ -16,7 +16,8 @@ export class StatisticsService {
   formatLabel(dates: Date[], duration: ScoreDuration): string[] {
     switch (duration) {
       case ScoreDuration.Year:
-        return dates.map((date) => date.toLocaleDateString(this.locale, { month: 'long' }));
+        // 'fr-FR' is required because this.locale returns "en" (i.e. English) when the browser is in English.
+        return dates.map((date) => date.toLocaleDateString('fr-FR', { month: 'long' }));
       default:
         return dates.map((date) =>
           date.toLocaleDateString(this.locale, { month: '2-digit', day: '2-digit' }),


### PR DESCRIPTION
Notion Ticket ~> https://www.notion.so/usealto/L-Home-Chart-labels-are-in-english-months-932e001bce9c4baf8303d8695ea0bdda?pvs=4

Before ~> 
<img width="1153" alt="Capture d’écran 2023-09-08 à 21 53 24" src="https://github.com/usealto/assessment-front/assets/65304634/9cf054d7-b445-4df0-9b2f-b131807a8c16">

After ~> 
<img width="1148" alt="Capture d’écran 2023-09-08 à 21 54 23" src="https://github.com/usealto/assessment-front/assets/65304634/2963ead4-20d1-49ff-a477-83c681f5e7ff">
